### PR TITLE
Fix PHP 8.4 implicit nullable parameter deprecations

### DIFF
--- a/src/ImageGenerator.php
+++ b/src/ImageGenerator.php
@@ -17,7 +17,7 @@ class ImageGenerator
         ?string $image,
         ?string $template,
         array $templateSettings = [],
-        string $logoUrl = null,
+        ?string $logoUrl = null,
         bool $isTest = false,
         bool $forceRegenerate = false
     )
@@ -53,7 +53,7 @@ class ImageGenerator
         ?string $image,
         ?string $template,
         array $templateSettings = [],
-        string $logoUrl = null,
+        ?string $logoUrl = null,
         bool $isTest = false,
         bool $forceRegenerate = false
     )
@@ -102,7 +102,7 @@ class ImageGenerator
         ?string $image,
         string $template,
         array $templateSettings = [],
-        string $logoUrl = null
+        ?string $logoUrl = null
     ) {
         $imageHeight = config('open-graphy.open_graph_image.height');
         $imageWidth = config('open-graphy.open_graph_image.width');


### PR DESCRIPTION
Add explicit nullable type hints (?string) to $logoUrl parameters in ImageGenerator::generate(), processGeneration(), and render() methods. In PHP 8.4, using a non-nullable type with a null default value is deprecated.